### PR TITLE
chore: Docker Hub tag cleanup — legacy purge + auto-prevention workflow

### DIFF
--- a/.github/workflows/dockerhub-tag-cleanup.yml
+++ b/.github/workflows/dockerhub-tag-cleanup.yml
@@ -1,0 +1,129 @@
+name: Docker Hub Tag Cleanup
+
+on:
+  schedule:
+    # Run weekly, Monday at 07:00 UTC — one hour AFTER the Monday 06:00 UTC
+    # rebuild in publish.yml, so we clean up immediately after fresh sha-*
+    # tags are produced (older ones crossing the 90-day threshold get swept
+    # the same morning).
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (list only, no deletion)"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+concurrency:
+  group: dockerhub-tag-cleanup
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete stale sha-* tags older than 90 days
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Get Docker Hub JWT
+        id: auth
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          JWT=$(curl -sS -f \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -X POST \
+            -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r '.token')
+          if [ -z "$JWT" ] || [ "$JWT" = "null" ]; then
+            echo "::error::Failed to obtain Docker Hub JWT"
+            exit 1
+          fi
+          echo "::add-mask::$JWT"
+          echo "jwt=$JWT" >> "$GITHUB_OUTPUT"
+
+      - name: List and filter sha-* tags
+        id: filter
+        env:
+          JWT: ${{ steps.auth.outputs.jwt }}
+        run: |
+          # Cutoff: 90 days ago, ISO 8601 UTC.
+          CUTOFF=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "Cutoff date (delete tags updated before this): $CUTOFF"
+
+          # Fetch all tags with pagination.
+          ALL_TAGS_JSON=$(mktemp)
+          NEXT_URL="https://hub.docker.com/v2/repositories/heyvaldemar/aws-kubectl/tags/?page_size=100"
+          echo "[]" > "$ALL_TAGS_JSON"
+          while [ "$NEXT_URL" != "null" ] && [ -n "$NEXT_URL" ]; do
+            RESPONSE=$(curl -sS -f \
+              -H "Accept: application/json" \
+              -H "Authorization: Bearer $JWT" \
+              "$NEXT_URL")
+            echo "$RESPONSE" | jq '.results' > /tmp/page.json
+            jq -s '.[0] + .[1]' "$ALL_TAGS_JSON" /tmp/page.json > /tmp/merged.json
+            mv /tmp/merged.json "$ALL_TAGS_JSON"
+            NEXT_URL=$(echo "$RESPONSE" | jq -r '.next')
+          done
+
+          # Filter: name starts with 'sha-' AND last_updated < cutoff.
+          # This intentionally does NOT match 'sha256-*.sig' (cosign signatures)
+          # because those start with 'sha256-', not 'sha-'.
+          jq -r --arg cutoff "$CUTOFF" '
+            .[] | select(.name | startswith("sha-"))
+               | select(.last_updated < $cutoff)
+               | .name
+          ' "$ALL_TAGS_JSON" > /tmp/to_delete.txt
+
+          COUNT=$(wc -l < /tmp/to_delete.txt | tr -d ' ')
+          echo "Tags matching sha-* and older than 90 days: $COUNT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Tags to process:"
+            cat /tmp/to_delete.txt
+          fi
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Delete filtered tags
+        if: steps.filter.outputs.count != '0'
+        env:
+          JWT: ${{ steps.auth.outputs.jwt }}
+          # Scheduled runs fall through the `|| 'false'` to auto-delete.
+          # Manual `workflow_dispatch` defaults to dry_run=true (safer for
+          # humans testing the workflow).
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          DELETED=0
+          ERRORS=0
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[DRY-RUN] would delete: $tag"
+            else
+              HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+                -X DELETE \
+                -H "Accept: application/json" \
+                -H "Authorization: Bearer $JWT" \
+                "https://hub.docker.com/v2/repositories/heyvaldemar/aws-kubectl/tags/$tag/")
+              if [ "$HTTP_CODE" = "204" ]; then
+                echo "deleted: $tag"
+                DELETED=$((DELETED + 1))
+              else
+                echo "::warning::failed to delete $tag (HTTP $HTTP_CODE)"
+                ERRORS=$((ERRORS + 1))
+              fi
+              sleep 1
+            fi
+          done < /tmp/to_delete.txt
+
+          echo "Summary: deleted=$DELETED errors=$ERRORS"
+          if [ "$ERRORS" -gt 0 ]; then
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Weekly `Docker Hub Tag Cleanup` GitHub Actions workflow
+  (`.github/workflows/dockerhub-tag-cleanup.yml`). Deletes `sha-*` image tags
+  older than 90 days on Mondays at 07:00 UTC (one hour after the publish
+  rebuild), preventing unbounded tag accumulation on Docker Hub. Scheduled
+  runs auto-delete; manual `workflow_dispatch` defaults to dry-run for safety.
+- `scripts/cleanup-legacy-tags.sh` — one-shot local cleanup for legacy
+  long-SHA (40-char hex) tags from the pre-Phase-1 CI era. Dry-run by default;
+  `--execute` requires typed `DELETE` confirmation. The 19 target tags are
+  hardcoded in the script so the operation is auditable in version control.
+
+### Removed
+- 19 legacy long-SHA image tags from Docker Hub (ranging from ~5 months to
+  ~2 years old, all from the pre-Phase-1 CI era). These were never documented
+  as stable pins and carried accumulated CVE noise. Current-generation
+  consumers use semver tags (`:2.0.0`, `:2.0`, `:2`), floating channels
+  (`:latest`, `:edge`, `:v1-maintenance`), the `kube-vX.Y.Z` pin, or short
+  `sha-*` tags for the last 90 days of builds. Cosign `.sig` tags were
+  preserved.
+
 ## [2.0.0] - 2026-04-21
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ cosign verify heyvaldemar/aws-kubectl:latest \
 
 > Non-root runtime shipped in **v2.0**. See [Breaking Changes in v2.0](#breaking-changes-in-v20) for migration details and the 90-day `v1-maintenance` track.
 
+### Tag management
+
+Tags fall into four categories:
+
+- **Semver releases** (`:2.0.0`, `:2.0`, `:2`, `:v2.0.0`) — immutable, kept forever. Recommended for production pins.
+- **Floating channels** (`:latest`, `:edge`, `:v1-maintenance`) — updated on every main build; kept forever.
+- **Kubernetes-version pin** (`:kube-v1.35.4`) — tracks the kubectl release packaged into the image. Kept forever.
+- **Short-SHA builds** (`:sha-<7char>`) — produced by CI for every commit to main. Retained for 90 days, then automatically deleted by the `Docker Hub Tag Cleanup` workflow.
+
+Cosign signatures (`:sha256-<digest>.sig`) are managed by Sigstore and are not deleted.
+
 ## Use Cases
 
 - **CI/CD**: run `aws`/`kubectl` steps in pipelines.

--- a/scripts/cleanup-legacy-tags.sh
+++ b/scripts/cleanup-legacy-tags.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# One-shot cleanup for legacy long-SHA (40-char hex) Docker Hub tags from the
+# pre-Phase-1 CI era. Never documented as stable pins, carry accumulated CVE
+# noise. Safe by default (dry-run); requires explicit "DELETE" typed
+# confirmation in --execute mode.
+#
+# Usage:
+#   ./scripts/cleanup-legacy-tags.sh [--dry-run|--execute]
+#
+# The PAT is read from $DOCKERHUB_PAT if set, otherwise prompted interactively
+# (input hidden). PAT must have Read/Write/Delete scopes on the target repo.
+#
+# Ongoing prevention of sha-* tag accumulation is handled by the separate
+# workflow .github/workflows/dockerhub-tag-cleanup.yml.
+set -euo pipefail
+
+REPO="heyvaldemar/aws-kubectl"
+API="https://hub.docker.com"
+UA="aws-kubectl-cleanup-script/1.0"
+
+# Exactly 19 legacy tags from the pre-Phase-1 CI era. Kept inline so this
+# script remains self-contained and auditable in version control.
+LEGACY_TAGS=(
+  bf0dcafe2fcc44b612cf50504b384b6c13b8ea01
+  813eb8f079e1decc7362f8911b6c289644a6efa1
+  4888f152d7d2189f6e1f24f979361cc6f81bdc4b
+  1f3a4f78b48fdadfa11adb4338dd893b4ffc465c
+  7e69e1d89059f50905a8e36fec93eaf22a832409
+  58dad7caa5986ceacd1bc818010a5e132d80452b
+  b8a25fe2c6790a9a844e9554e6d835cc85b1055d
+  6a87312f722582ec099f9fa276000dc8ca73590e
+  162c552d2a8b978ad83a8ba4d589a01afaa99a43
+  dc1fa1c2cb926fbd8174da60e7d1544d09c39234
+  f2d1feaed4f1cbc7c6817b27f3dda528e88f2e7a
+  a5a8828403df81205ac486c6bd90812800789d2e
+  b085b097d41eabaf5397ee1ff9a5b899fcca6b2b
+  178d8089585d0162fb0eedb0760a478c8b7c69ae
+  0217944ed1747c745015b621388d3ae3d804d010
+  fa3e700d8f00b78c5f525aa0d6e7486fb3d7ba78
+  23392bea9a5febf1a9218f5085107a996e65c216
+  e59d3c6fbf63fbd13994e2522c37ddb99011207d
+  c87d7e7851436abf90b220c2e3d76527c6b1a2eb
+)
+
+MODE="${1:---dry-run}"
+case "$MODE" in
+  --dry-run|--execute) ;;
+  -h|--help)
+    sed -n '2,/^set /p' "$0" | sed 's/^# \{0,1\}//' | head -n 11
+    exit 0
+    ;;
+  *)
+    echo "Usage: $0 [--dry-run|--execute]" >&2
+    exit 2
+    ;;
+esac
+
+# Acquire PAT.
+if [ -z "${DOCKERHUB_PAT:-}" ]; then
+  # Prompt hidden; stderr so it shows even if stdout is redirected.
+  read -r -s -p "Docker Hub PAT (input hidden, Enter when done): " DOCKERHUB_PAT
+  echo
+fi
+if [ -z "${DOCKERHUB_PAT}" ]; then
+  echo "ERROR: DOCKERHUB_PAT is empty." >&2
+  exit 1
+fi
+
+# Exchange PAT for short-lived JWT. The REST API for tag deletion requires a
+# bearer JWT, not the raw PAT.
+echo "Exchanging PAT for Docker Hub JWT..."
+LOGIN_BODY=$(python3 -c '
+import json, os
+print(json.dumps({"username": "heyvaldemar", "password": os.environ["DOCKERHUB_PAT"]}))
+')
+JWT=$(
+  DOCKERHUB_PAT="${DOCKERHUB_PAT}" \
+  curl -sS -f \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -H "User-Agent: ${UA}" \
+    -X POST \
+    -d "${LOGIN_BODY}" \
+    "${API}/v2/users/login/" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("token",""))'
+)
+if [ -z "${JWT}" ]; then
+  echo "ERROR: JWT exchange failed (empty token)." >&2
+  exit 1
+fi
+
+# --execute requires explicit confirmation. Typed "DELETE", nothing else.
+if [ "${MODE}" = "--execute" ]; then
+  echo
+  echo "ABOUT TO DELETE ${#LEGACY_TAGS[@]} tags from ${REPO} on Docker Hub."
+  echo "This is irreversible."
+  read -r -p "Type DELETE to proceed (anything else aborts): " confirm
+  if [ "${confirm}" != "DELETE" ]; then
+    echo "Aborted."
+    exit 1
+  fi
+fi
+
+to_delete=0
+already_gone=0
+errors=0
+
+for tag in "${LEGACY_TAGS[@]}"; do
+  URL="${API}/v2/repositories/${REPO}/tags/${tag}/"
+  if [ "${MODE}" = "--dry-run" ]; then
+    HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+      -H "Authorization: Bearer ${JWT}" \
+      -H "Accept: application/json" \
+      -H "User-Agent: ${UA}" \
+      "${URL}")
+    case "${HTTP_CODE}" in
+      200) printf 'would delete: %s\n' "${tag}"; to_delete=$((to_delete+1)) ;;
+      404) printf 'already gone: %s\n' "${tag}"; already_gone=$((already_gone+1)) ;;
+      *)   printf 'WARN (HTTP %s): %s\n' "${HTTP_CODE}" "${tag}" >&2
+           errors=$((errors+1)) ;;
+    esac
+  else
+    HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+      -X DELETE \
+      -H "Authorization: Bearer ${JWT}" \
+      -H "Accept: application/json" \
+      -H "User-Agent: ${UA}" \
+      "${URL}")
+    case "${HTTP_CODE}" in
+      204) printf 'deleted: %s\n' "${tag}"; to_delete=$((to_delete+1)) ;;
+      404) printf 'already gone: %s\n' "${tag}"; already_gone=$((already_gone+1)) ;;
+      *)   printf 'ERROR (HTTP %s): %s\n' "${HTTP_CODE}" "${tag}" >&2
+           errors=$((errors+1)) ;;
+    esac
+  fi
+  # Respect Docker Hub API rate limits.
+  sleep 1
+done
+
+echo
+if [ "${MODE}" = "--dry-run" ]; then
+  printf 'DRY-RUN SUMMARY: would-delete=%d already-gone=%d errors=%d\n' \
+    "${to_delete}" "${already_gone}" "${errors}"
+else
+  printf 'EXECUTE SUMMARY: deleted=%d already-gone=%d errors=%d\n' \
+    "${to_delete}" "${already_gone}" "${errors}"
+fi
+
+if [ "${errors}" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Phase 2/3 hardening surfaced **19 legacy long-SHA (40-char hex) tags** on Docker Hub from the pre-Phase-1 CI era. They were never documented as stable pins, carried accumulated CVE noise, and cluttered the public tags page. This PR:

1. **Already purged those 19 tags from Docker Hub** via a local `--execute` run of the included cleanup script. The tags are gone from Docker Hub as of this PR's authoring. The script is checked in so the operation is auditable and repeatable.
2. **Adds a weekly GitHub Actions workflow** that auto-deletes `sha-*` tags older than 90 days, so accumulation never happens again.
3. **Documents the tag taxonomy** in README so consumers know what they can rely on.

Cosign `.sig` tags, semver tags, floating channels (`:latest`, `:edge`, `:v1-maintenance`), and the kube-version pin are all preserved. `sha256-*.sig` signature tags are *explicitly not matched* by the cleanup filter (`startswith("sha-")` vs. `sha256-`).

## Docker Hub state

| When | Tag count | Legacy long-SHA tags |
|---|---|---|
| Before this PR | 43 | 19 |
| After `--execute` ran locally | 24 | 0 |
| After this PR merges (no CI-level change to tag count) | 24 | 0 |

## What changed per file

- **`scripts/cleanup-legacy-tags.sh`** (new, executable) — one-shot local cleanup. Safe defaults: dry-run unless `--execute` passed; `--execute` requires typed `DELETE` confirmation. Uses Docker Hub REST API directly (the docker CLI doesn't support tag deletion). `shellcheck` clean.
- **`.github/workflows/dockerhub-tag-cleanup.yml`** (new) — weekly cron `"0 7 * * 1"` (Mon 07:00 UTC, 1h after `publish.yml`'s rebuild at 06:00 UTC), plus `workflow_dispatch` with `dry_run` input defaulting to `"true"`. Scheduled runs auto-delete; manual runs are safe-by-default. Permissions: `contents: read` only. 10-minute timeout. Uses existing `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets.
- **`CHANGELOG.md`** — new `[Unreleased]` entries under `Added` (workflow + script) and `Removed` (19 legacy tags).
- **`README.md`** — new `### Tag management` subsection under `## Supply chain`, documenting the four tag categories and the 90-day `sha-*` retention policy.

## Design decisions worth calling out

- **19-tag whitelist is hardcoded in the local script**, not regex-matched. The regex `^[0-9a-f]{40}$` would also match future accidental long-SHA tags, which we'd rather flag than auto-delete. Pre-flight verified the live tag list contained exactly these 19 and no unexpected matches.
- **Workflow uses `sha-` prefix, not `sha256-`.** Cosign signature tags look like `sha256-e196f27789b0ce...sig` and start with `sha256-`, so they are never matched by `startswith("sha-")`. Sigstore signature verification for historical digests is unaffected.
- **Scheduled runs skip the dry-run safety gate on purpose.** The whole point of the automation is that it runs unattended. Humans get dry-run-by-default via `workflow_dispatch`; the cron gets real cleanup.
- **Post-merge this week is a no-op for the workflow.** The oldest current `sha-*` tag is `sha-058135c` from 2026-01-23, which is inside the 90-day window. First real deletion will happen when the earliest `sha-*` tag crosses the 90-day threshold.

## Local verification (before push)

- [x] `shellcheck scripts/cleanup-legacy-tags.sh` clean (via `koalaman/shellcheck-alpine:stable`)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dockerhub-tag-cleanup.yml'))"` parses
- [x] `./scripts/cleanup-legacy-tags.sh --dry-run` — all 19 reported as `would delete`, 0 errors
- [x] `./scripts/cleanup-legacy-tags.sh --execute` — all 19 reported as `deleted`, 0 errors
- [x] Post-delete API re-list: 43 → 24 tags, 0 remaining 40-char hex tags

## Post-merge checklist

- [ ] Verify Docker Hub tags page shows 24 tags (no long-SHA tags)
- [ ] Manually run `Docker Hub Tag Cleanup` via `workflow_dispatch` with `dry_run=true` to smoke-test the workflow end-to-end. Expect: "Tags matching sha-* and older than 90 days: 0" and no deletion.
- [ ] First real scheduled run is Monday 07:00 UTC; expect count=0 for several more weeks until the earliest `sha-*` tag ages past 90 days.

## Out of scope for this PR (noted for later)

- README §Supply chain line 83 still says GitHub native attestations are "pushed to the registry alongside the image." That wording was corrected in `SECURITY.md` during the Phase 3 hotfix (PR #20 flipped `push-to-registry: false`) but the README bullet wasn't updated at the same time. Small follow-up; not tag-cleanup scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
