### PR TITLE
chore: add OpenSSF Scorecard workflow + badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Weekly on Tuesdays at 06:00 UTC — after the Monday rebuild (publish.yml,
+    # 06:00 UTC) and Monday cleanup (dockerhub-tag-cleanup.yml, 07:00 UTC) have
+    # finished. Keeps the Scorecard score in sync with any weekly change in
+    # pinned-dependency posture.
+    - cron: "0 6 * * 2"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Scorecard needs broad read access to score the repo; individual jobs
+# narrow this further for the steps that need write scopes.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Needed for SARIF upload to the Security tab.
+      security-events: write
+      # Needed to publish results to the public OpenSSF API (scorecard.dev).
+      id-token: write
+      # Needed to read the repo state and workflow history.
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the public OpenSSF API so the badge at
+          # api.scorecard.dev/projects/.../badge populates. No token needed
+          # for public repos; the workflow's OIDC token authenticates.
+          publish_results: true
+
+      - name: Upload Scorecard results as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- OpenSSF Scorecard analysis workflow (`.github/workflows/scorecard.yml`).
+  Runs weekly on Tuesdays at 06:00 UTC (after the Monday rebuild and cleanup
+  workflows), on every push to `main`, and on branch-protection-rule changes.
+  Publishes results to the public OpenSSF API (scorecard.dev viewer) and
+  uploads SARIF to the GitHub Security tab. README badge added next to the
+  license badge; the badge populates automatically after the first run
+  completes on `main`.
 - Weekly `Docker Hub Tag Cleanup` GitHub Actions workflow
   (`.github/workflows/dockerhub-tag-cleanup.yml`). Deletes `sha-*` image tags
   older than 90 days on Mondays at 07:00 UTC (one hour after the publish

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Docker Image Size](https://img.shields.io/docker/image-size/heyvaldemar/aws-kubectl/latest.svg)](https://hub.docker.com/r/heyvaldemar/aws-kubectl/tags)
 [![Build Status](https://github.com/heyvaldemar/aws-kubectl-docker/actions/workflows/publish.yml/badge.svg?branch=main)](https://github.com/heyvaldemar/aws-kubectl-docker/actions/workflows/publish.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/heyvaldemar/aws-kubectl-docker/badge)](https://scorecard.dev/viewer/?uri=github.com/heyvaldemar/aws-kubectl-docker)
 
 This image streamlines work with Amazon Web Services (AWS) and Kubernetes by bundling **AWS CLI v2** (`aws`) and **kubectl** on **Ubuntu 24.04**. It also includes `jq`, `curl`, `unzip`, and `envsubst` (from `gettext-base`). Perfect for CI/CD steps, automation, and reproducible local scripting.
 


### PR DESCRIPTION
## Summary

Enables [OpenSSF Scorecard](https://scorecard.dev) analysis on this repo. Scorecard is a free service from the Open Source Security Foundation that scores public OSS repos 0–10 on supply-chain security posture — branch protection, code review enforcement, Dependabot/pinned-dependencies, SAST tooling, token permissions, signed releases, and more.

Runs weekly (Tuesdays 06:00 UTC, after the Monday rebuild + tag cleanup), on every push to `main`, and on branch-protection-rule changes. Publishes results to the public OpenSSF API so a README badge at `api.scorecard.dev/.../badge` populates automatically; also uploads SARIF to the GitHub Security tab.

Third-party validation of the Phase 1/2/3 hardening work — the score should be respectable out of the gate (pinned actions, Dependabot, branch protection, cosign signing, SBOM/provenance, vulnerability scan) and improve as we keep hardening.

## What changed per file

- **`.github/workflows/scorecard.yml`** (new) — SHA-pinned workflow using `ossf/scorecard-action@v2.4.3`, `actions/checkout@v6` (same SHA as `publish.yml`), `actions/upload-artifact@v7.0.1`, `github/codeql-action/upload-sarif@v4.35.2` (same SHA as `publish.yml`). Workflow-level `permissions: read-all`; job-level narrows to `security-events: write`, `id-token: write`, `contents: read`, `actions: read`. `persist-credentials: false` on checkout. 15-minute timeout. Triggers: `branch_protection_rule`, weekly `schedule`, `push main`, `workflow_dispatch`.
- **`README.md`** — one new badge line after the existing License badge, linking to the scorecard.dev viewer.
- **`CHANGELOG.md`** — new entry under `[Unreleased] → Added` describing the workflow. Existing Phase 2/3/tag-cleanup entries preserved untouched.

## SHA-pin choices (for reviewer confirmation)

| Action | Tag | SHA | Rationale |
|---|---|---|---|
| `actions/checkout` | `v6` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | Same SHA as `publish.yml`; consistency across workflows |
| `ossf/scorecard-action` | `v2.4.3` | `99c09fe975337306107572b4fdf4db224cf8e2f2` | Latest stable |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | Latest stable major |
| `github/codeql-action/upload-sarif` | `v4.35.2` | `95e58e9a2cdfd71adc6e0353d5c52f41a045d225` | Same SHA as `publish.yml` (post-Dependabot #19) |

## Permissions design

Workflow-level `permissions: read-all` is **intentional**, not lax. Scorecard's own "Token-Permissions" check actually rewards this pattern (workflow-level broad read + job-level narrow writes) because it documents that the repo authors considered the split explicitly. A pure job-level-only config would require listing every implicit default scope.

Job-level only adds three specific write scopes:
- `security-events: write` — SARIF upload
- `id-token: write` — OIDC authentication to the OpenSSF API for `publish_results: true`
- `actions: read` + `contents: read` — explicit read affordances for Scorecard analysis of workflow files and source

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses
- [ ] Post-merge: `push main` trigger fires → first Scorecard run appears under Actions tab within ~1 min
- [ ] Post-merge: first run completes successfully within ~2–5 min
- [ ] Post-merge: README badge populates (may show "no data" for the first ~5–10 min, then fills with the score)
- [ ] Post-merge: SARIF results appear under Security → Code scanning with category `scorecard`
- [ ] Post-merge: scorecard.dev viewer page resolves (https://scorecard.dev/viewer/?uri=github.com/heyvaldemar/aws-kubectl-docker) and shows a per-check breakdown

## Score expectations

No commitments here — the actual score lands when the first run completes. Based on the current repo state, reasonable expectations for the individual checks:

- ✅ **Pinned-Dependencies** — all GitHub Actions pinned by SHA with version comment. Dockerfile digest-pinned.
- ✅ **Dependency-Update-Tool** — Dependabot configured with groups for github-actions + docker ecosystems.
- ✅ **Token-Permissions** — per-job least-privilege in `publish.yml`; `read-all` + job-narrow in `scorecard.yml`.
- ✅ **Signed-Releases** — cosign keyless signing of every pushed digest.
- ✅ **SAST** — Hadolint + ShellCheck in `publish.yml`; Trivy scan; CodeQL SARIF upload.
- ✅ **License** — MIT, root `LICENSE` file.
- ✅ **Security-Policy** — `SECURITY.md`.
- ✅ **Maintained** — active commit history.
- ⚠️ **Branch-Protection** — recently enabled (commit `b79e26b "test branch protection"`); Scorecard can only see it if the token has admin read, which the default GITHUB_TOKEN doesn't — so this check may show "inconclusive" until you add a PAT or the Scorecard team's token-oracle covers it. That's fine, no action needed.
- ⚠️ **Code-Review** — solo-maintainer repo. If branch protection requires PR review and you bypass yourself, Scorecard may or may not credit that depending on the signal.
- ⚠️ **Fuzzing** — none. Not applicable to a CLI-tooling image repo; acceptable to leave unscored.
- ⚠️ **CII-Best-Practices** — not registered with the CII Best Practices badge program; acceptable to skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
