### PR TITLE
fix(ci): pin ossf/scorecard-action to commit SHA, not tag object SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sha-*` tags for the last 90 days of builds. Cosign `.sig` tags were
   preserved.
 
+### Fixed
+- OpenSSF Scorecard publication to `api.scorecard.dev` — corrected the
+  `ossf/scorecard-action` pin from the annotated tag object SHA (`99c09fe`)
+  to the actual commit SHA (`4eaacf0`). The previous pin used the tag object
+  SHA returned by GitHub's `git/refs/tags/...` API; Scorecard's
+  imposter-commit verification rejected it and refused to publish results,
+  blocking README badge activation. `v2.4.3` itself is unchanged.
+
 ## [2.0.0] - 2026-04-21
 
 ### BREAKING CHANGES


### PR DESCRIPTION
## Summary

The Scorecard workflow added in PR #23 ran successfully but the README badge never populated — `api.scorecard.dev` refused to publish results, and the Actions log surfaced an "imposter commit" error against the `ossf/scorecard-action` pin.

Root cause: the pin was the annotated **tag object SHA** for `v2.4.3`, not the underlying **commit SHA**. Scorecard's self-verification computes real commit hashes at runtime and rejects any `uses:` SHA that doesn't match a commit in the action's repo history — which tag object SHAs never do.

One-line fix: swap `99c09fe…` (tag object) for `4eaacf0…` (commit). Version `v2.4.3` itself is unchanged; only the pointer changes.

## Diagnostic output (from `gh api`)

```console
$ gh api repos/ossf/scorecard-action/git/refs/tags/v2.4.3 --jq '.object'
{
  "sha": "99c09fe975337306107572b4fdf4db224cf8e2f2",
  "type": "tag",
  "url": "https://api.github.com/repos/ossf/scorecard-action/git/tags/99c09fe975337306107572b4fdf4db224cf8e2f2"
}

$ gh api repos/ossf/scorecard-action/git/tags/99c09fe975337306107572b4fdf4db224cf8e2f2 --jq '.object'
{
  "sha": "4eaacf0543bb3f2c246792bd56e8cdeffafb205a",
  "type": "commit",
  "url": "https://api.github.com/repos/ossf/scorecard-action/git/commits/4eaacf0543bb3f2c246792bd56e8cdeffafb205a"
}
```

`.type: "tag"` on the first response is the giveaway — it's a tag *object*, one dereferencing hop away from the commit. `.type: "commit"` on the second confirms the real target.

Verified locally the same way via `git ls-remote`:

```console
$ git ls-remote --tags https://github.com/ossf/scorecard-action.git refs/tags/v2.4.3 refs/tags/v2.4.3^{}
99c09fe975337306107572b4fdf4db224cf8e2f2	refs/tags/v2.4.3
4eaacf0543bb3f2c246792bd56e8cdeffafb205a	refs/tags/v2.4.3^{}
```

The `^{}` suffix is git's syntax for "dereference this tag to its commit". An annotated tag has both lines; a lightweight tag has only the first.

## Why only this one pin

I checked all four pins in `scorecard.yml`:

| Action | Pin | Tag kind | Assessment |
|---|---|---|---|
| `ossf/scorecard-action@99c09fe...` | v2.4.3 | **Annotated**, I grabbed the tag object SHA | **Broken — this PR** |
| `actions/checkout@de0fac2e...` | v6 | Lightweight (no `^{}` line) | ✅ correct (commit SHA) |
| `actions/upload-artifact@043fb46d...` | v7.0.1 | Lightweight | ✅ correct (commit SHA) |
| `github/codeql-action/upload-sarif@95e58e9a...` | v4.35.2 | Annotated, but Dependabot dereferenced | ✅ correct (commit SHA, matches `^{}`) |

`publish.yml` pins were set by Dependabot, which always dereferences annotated tags correctly, so they're unaffected.

## Root cause of the mistake (for process improvement)

My local SHA lookup during PR #23 used:

```bash
git ls-remote --tags <repo> | grep -v '\^{}$' | ...
```

The `grep -v '\^{}$'` filter was intended to clean up ls-remote's dual-line output for annotated tags, but it did the wrong thing — it kept the tag-object line and dropped the commit-dereference line. Correct filter for future pins is the opposite:

```bash
git ls-remote --tags <repo> refs/tags/<tag> refs/tags/<tag>^{} \
  | awk 'END { print $1 }'
```

…or simply `gh api repos/<repo>/git/ref/tags/<tag> --jq '.object.sha'` followed by a type check and, if `"tag"`, a second hop.

## What changed per file

- **`.github/workflows/scorecard.yml`** — one-line SHA swap on the `Run Scorecard analysis` step. Version comment `# v2.4.3` kept.
- **`CHANGELOG.md`** — new `### Fixed` subsection under `[Unreleased]` (placed after the existing `### Removed` per Keep-a-Changelog canonical order).

## Test plan (post-merge)

- [ ] Scorecard workflow triggers on `push main` and runs green (same as before — the workflow itself wasn't broken, only the badge publication).
- [ ] `api.scorecard.dev/projects/github.com/heyvaldemar/aws-kubectl-docker/badge` returns a real score-carrying SVG instead of the "no data" placeholder within ~5–10 min.
- [ ] `scorecard.dev/viewer/?uri=github.com/heyvaldemar/aws-kubectl-docker` shows the per-check breakdown page.
- [ ] README badge at the top of the repo renders the numeric score.
- [ ] SARIF still uploads to Security → Code scanning with category `scorecard` (unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
