### PR TITLE
docs: align Tag management section with Docker Hub immutability policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,13 @@ cosign verify heyvaldemar/aws-kubectl:latest \
 
 ## Tag management
 
-Tags fall into four categories:
+Tags fall into five categories:
 
-- **Semver releases** (`:2.0.0`, `:2.0`, `:2`, `:v2.0.0`) — immutable, kept forever. Recommended for production pins.
+- **Exact semver** (`:2.0.0`, `:v2.0.0`) — immutable on Docker Hub; the digest under these tags never changes after first push. Recommended for production pins.
+- **Rolling semver** (`:2.0`, `:2`) — mutable; re-targets to the newest patch (and minor) within the major on each release. Kept forever.
 - **Floating channels** (`:latest`, `:edge`, `:v1-maintenance`) — updated on every main build; kept forever.
-- **Kubernetes-version pin** (`:kube-v1.35.4`) — tracks the kubectl release packaged into the image. Kept forever.
-- **Short-SHA builds** (`:sha-<7char>`) — produced by CI for every commit to main. Retained for 90 days, then automatically deleted by the `Docker Hub Tag Cleanup` workflow.
+- **Kubernetes-version pin** (`:kube-v1.35.4`) — tracks the kubectl release packaged into the image. Immutable on Docker Hub; kept forever.
+- **Short-SHA builds** (`:sha-<7char>`) — produced by CI for every commit to main. Immutable while live; retained for 90 days, then automatically deleted by the `Docker Hub Tag Cleanup` workflow.
 
 Cosign signatures (`:sha256-<digest>.sig`) are managed by Sigstore and are not deleted.
 


### PR DESCRIPTION
## Summary

Precision-edit of `## Tag management` in README so it accurately describes which tags are immutable on Docker Hub and which are floating.

## Background

Docker Hub tag-mutability regex for this repo is:

```
^(v?[0-9]+\.[0-9]+\.[0-9]+|sha-.*|kube-v.*)\$
```

This matches immutable:
- Exact semver `X.Y.Z` (with or without `v` prefix)
- `sha-*` tags
- `kube-v*` tags

Leaves mutable (correctly, by design):
- Rolling `:X.Y` and `:X` floating tags
- `:latest`, `:edge`, `:v1-maintenance` channels

The previous README \"Tag management\" section listed all four semver formats (`:2.0.0`, `:2.0`, `:2`, `:v2.0.0`) under a single \"immutable, kept forever\" bullet. That was wrong for `:2.0` and `:2` (which must float) and didn't spell out `:kube-v*` as immutable.

## What changed

README `## Tag management` now splits into five accurate categories:

| Category | Example | Mutable? | Retention |
|---|---|---|---|
| Exact semver | `:2.0.0`, `:v2.0.0` | No | Kept forever |
| Rolling semver | `:2.0`, `:2` | Yes (re-targets on each release) | Kept forever |
| Floating channels | `:latest`, `:edge`, `:v1-maintenance` | Yes | Kept forever |
| Kubernetes-version pin | `:kube-v1.35.4` | No | Kept forever |
| Short-SHA builds | `:sha-<7char>` | No (while live) | 90 days, then purged |

Cosign signatures (`:sha256-<digest>.sig`) unchanged.

## Out of scope

This README edit assumes the Docker Hub tag mutability regex has been updated to `^(v?[0-9]+\.[0-9]+\.[0-9]+|sha-.*|kube-v.*)\$` — adding the `v?` prefix so `:v2.0.0` is immutable, not just `:2.0.0`. That is a one-time UI change in Docker Hub repository settings (not a repo change).

## Test plan

- [ ] Render check: README \"Tag management\" section shows five bullets.
- [ ] TOC entry `[Tag management](#tag-management)` resolves correctly.
- [ ] No other section affected; diff is scoped to one section.
- [ ] Post-merge: Docker Hub README mirror picks up the new section via `peter-evans/dockerhub-description` on next main push.