### PR TITLE
docs(changelog): remove stale BIO.md references from [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--execute` requires typed `DELETE` confirmation. The 19 target tags are
   hardcoded in the script so the operation is auditable in version control.
 - Cosign Verified badge in README linking to the attestations page.
-- `BIO.md` — maintainer bio with the full Docker CEO recognition video and
-  quote, linked from the README footer.
 
 ### Changed
 - README restructured for evaluator-first audience: added "Why this image?"
@@ -41,9 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Obsolete "Tagging / Versioning Policy" section removed — superseded by the
   newer "Tag management" section, which reflects current tag categories and
   the 90-day `sha-*` retention policy.
-- ABOUT section in README trimmed to a six-line maintainer footer; the full
-  bio, Docker CEO recognition video, and Scott Johnston quote moved to
-  `BIO.md`.
+- ABOUT section in README trimmed to a compact maintainer footer (YouTube · Blog · LinkedIn). The Docker CEO recognition video and Scott Johnston quote live in the profile README at [github.com/heyvaldemar/heyvaldemar](https://github.com/heyvaldemar/heyvaldemar), not duplicated into individual repos.
 
 ### Removed
 - 19 legacy long-SHA image tags from Docker Hub (ranging from ~5 months to


### PR DESCRIPTION
## Summary

Documentation hygiene — no functional change. Identified during the post-[self-host-repo-hardening-runbook v1.2.0](https://github.com/heyvaldemar/self-host-repo-hardening-runbook/releases/tag/v1.2.0) audit of the reference implementations (this repo + keycloak).

`CHANGELOG.md` [Unreleased] retained two entries describing an intermediate state that was reverted within the same unreleased cycle — the briefly-lived `BIO.md`. It was added in an earlier PR and then removed in [PR #27](https://github.com/heyvaldemar/aws-kubectl-docker/pull/27) ("docs: add Pinning guidance section + remove BIO.md"). The file no longer exists (`ls BIO.md` → not found).

Net user-visible change before the first release tag: zero. So the changelog shouldn't document either the add or the "moved to BIO.md" — it should reflect the final state that will ship.

## What changes

Two edits in `CHANGELOG.md` [Unreleased]:

1. **Removed** the Added bullet:
   ```
   - `BIO.md` — maintainer bio with the full Docker CEO recognition video and
     quote, linked from the README footer.
   ```

2. **Rewrote** the Changed bullet from:
   ```
   - ABOUT section in README trimmed to a six-line maintainer footer; the full
     bio, Docker CEO recognition video, and Scott Johnston quote moved to
     `BIO.md`.
   ```
   to:
   ```
   - ABOUT section in README trimmed to a compact maintainer footer (YouTube · Blog · LinkedIn). The Docker CEO recognition video and Scott Johnston quote live in the profile README at [github.com/heyvaldemar/heyvaldemar](https://github.com/heyvaldemar/heyvaldemar), not duplicated into individual repos.
   ```

The new wording accurately describes where the content lives now: in the profile README (verified), not in `BIO.md` (which doesn't exist).

## Verification

- [x] `grep -n "BIO.md" CHANGELOG.md` — 0 matches after edits (was 2 before).
- [x] No other file references `BIO.md` (grep across repo).
- [x] `ls BIO.md` — not found (file correctly absent).
- [x] Profile README at `github.com/heyvaldemar/heyvaldemar` does contain the Docker CEO video + Scott Johnston quote (verified).

## Diff stats

```
CHANGELOG.md | 6 +-----
1 file changed, 1 insertion(+), 5 deletions(-)
```

Scope intentionally narrow — one stale-reference cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)