### PR TITLE
fix(ci): scope kube-v* tag to semver releases, harden cosign step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=sha-,format=short
-            type=raw,value=kube-${{ steps.kube.outputs.version }}
+            type=raw,value=kube-${{ steps.kube.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
           labels: |
             org.opencontainers.image.title=aws-kubectl
             org.opencontainers.image.description=Ubuntu 24.04 image bundling AWS CLI v2, kubectl, jq, envsubst, curl and ca-certificates for CI/CD and local tooling.
@@ -157,7 +157,17 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+          set -euo pipefail
+          if [ -z "${TAGS}" ] || [ -z "${DIGEST}" ]; then
+            echo "ERROR: TAGS or DIGEST is empty" >&2
+            exit 1
+          fi
+          echo "${TAGS}" | while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Signing: ${tag}@${DIGEST}"
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+          echo "All tags signed successfully"
 
   scan-trivy:
     name: Scan published image with Trivy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserved.
 
 ### Fixed
+- CI workflow: `kube-v*` tag now only generated on semver tag releases (was
+  previously generated on every push, causing Docker Hub immutability conflicts
+  after the immutability policy was enabled). Main pushes no longer fail at
+  the publish step. The cosign signing step now runs reliably for `:latest`,
+  restoring signatures on floating tags.
+- CI workflow: cosign signing step now uses `set -euo pipefail` and explicit
+  per-tag error handling, preventing silent partial signing failures.
 - OpenSSF Scorecard publication to `api.scorecard.dev` — corrected the
   `ossf/scorecard-action` pin from the annotated tag object SHA (`99c09fe`)
   to the actual commit SHA (`4eaacf0`). The previous pin used the tag object

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Tags fall into five categories:
 - **Exact semver** (`:2.0.0`, `:v2.0.0`) — immutable on Docker Hub; the digest under these tags never changes after first push. Recommended for production pins.
 - **Rolling semver** (`:2.0`, `:2`) — mutable; re-targets to the newest patch (and minor) within the major on each release. Kept forever.
 - **Floating channels** (`:latest`, `:edge`, `:v1-maintenance`) — updated on every main build; kept forever.
-- **Kubernetes-version pin** (`:kube-v1.35.4`) — tracks the kubectl release packaged into the image. Immutable on Docker Hub; kept forever.
+- **Kubernetes-version pin** (`:kube-v1.36.0`) — generated only on semver releases. Tracks the kubectl release packaged into the image at the time of that release. Immutable on Docker Hub; kept forever.
 - **Short-SHA builds** (`:sha-<7char>`) — produced by CI for every commit to main. Immutable while live; retained for 90 days, then automatically deleted by the `Docker Hub Tag Cleanup` workflow.
 
 Cosign signatures (`:sha256-<digest>.sig`) are managed by Sigstore and are not deleted.


### PR DESCRIPTION
## Summary

- **Root cause:** `docker/metadata-action` was generating `kube-v${version}` on every event including main pushes. After Docker Hub tag immutability was enabled (regex includes `kube-v.*`), every main commit since 2026-04-24 has tried to re-push the same `kube-v1.36.0` tag and been rejected. The build step failed before the cosign sign step could run, so `:latest`, `:edge`, and `:sha-*` digests were pushed but never signed.
- **Fix (workflow):** scope the `kube-v*` tag to `startsWith(github.ref, 'refs/tags/')`. Main pushes get `:latest`, `:edge`, `:sha-<short>` only. Tag releases get those + semver + `kube-v*`.
- **Fix (cosign hardening):** replace `xargs -I {}` with a `set -euo pipefail` while-loop that fails fast on empty `TAGS`/`DIGEST`, logs each tag being signed, and surfaces per-tag failures instead of silently masking them at the end of a pipe.
- **Docs:** README Tag management bullet for `kube-v*` clarified as release-only and version bumped to `v1.36.0`. CHANGELOG `[Unreleased]` documents the regression and fix.

## Affected runs since 2026-04-24

All failed at the registry push step with `denied: ... immutability settings`:
- [`24869446993`](https://github.com/heyvaldemar/aws-kubectl-docker/actions/runs/24869446993) — main push, 2026-04-24 02:40 UTC
- [`24981418704`](https://github.com/heyvaldemar/aws-kubectl-docker/actions/runs/24981418704) — weekly cron, 2026-04-27 07:09 UTC
- [`25010492751`](https://github.com/heyvaldemar/aws-kubectl-docker/actions/runs/25010492751) — main push, 2026-04-27 17:44 UTC
- [`25015177224`](https://github.com/heyvaldemar/aws-kubectl-docker/actions/runs/25015177224) — dependabot merge, 2026-04-27 19:29 UTC

`:2.0.0` and other semver tags signed at v2.0.0 release time are unaffected (release event predates immutability policy enablement).

## Constraints respected

- Docker Hub immutability policy untouched — `kube-v*` stays immutable when published; only the trigger condition for publishing it changed.
- Cosign v2.6.1 pin preserved (v2 → v3 migration tracked separately).
- `docker/metadata-action` SHA pin preserved.
- Multi-arch, SBOM, SLSA provenance, and GitHub attestations all preserved.

## Test plan

- [ ] Branch CI run completes successfully (`Build and Publish Docker Image` job: success)
- [ ] `Sign image with cosign (keyless)` step runs and prints `Signing: <tag>@<digest>` for each tag (PR builds skip the step via the existing `if: github.event_name != 'pull_request'`, so verification will need to occur on the post-merge main push)
- [ ] `DOCKER_METADATA_OUTPUT_JSON` line in build logs shows `:latest`, `:edge`, `:sha-<short>` and does NOT include `:kube-v1.36.0`
- [ ] After merge, `cosign verify heyvaldemar/aws-kubectl:latest --certificate-identity-regexp "https://github.com/heyvaldemar/aws-kubectl-docker/.*" --certificate-oidc-issuer "https://token.actions.githubusercontent.com"` succeeds
- [ ] `cosign verify heyvaldemar/aws-kubectl:edge` succeeds (same identity/issuer flags)
- [ ] `cosign verify heyvaldemar/aws-kubectl:2.0.0` still succeeds (regression check on previously-signed tag)
- [ ] Next semver release will publish `kube-v*` tag exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)