### PR TITLE
chore(ci): skip cosign install on PR builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,6 +141,7 @@ jobs:
           push-to-registry: false
 
       - name: Install cosign
+        if: github.event_name != 'pull_request'
         # Install Cosign v2.6.1 explicitly: cosign-installer v4 defaults to Cosign
         # v3.x, which changes container signature storage to OCI 1.1 referring
         # artifacts. Docker Hub's OCI referrer credential handoff proved unreliable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserved.
 
 ### Fixed
+- CI workflow: `Install cosign` step now skipped on PR builds, mirroring the existing PR-skip pattern on `Login to Docker Hub`, `Attest build provenance`, and `Sign image with cosign`. Removes ~30s of wasted work per PR build and eliminates GitHub releases CDN as a PR-build flake surface (hit a transient 502 on PR #32 requiring a re-run).
 - CI workflow: `kube-v*` tag now only generated on semver tag releases (was
   previously generated on every push, causing Docker Hub immutability conflicts
   after the immutability policy was enabled). Main pushes no longer fail at


### PR DESCRIPTION
Mirrors existing PR-skip pattern. See commit message for full context.

## What changed

Adds `if: github.event_name != 'pull_request'` to the `Install cosign` step in `.github/workflows/publish.yml`.

## Why

The workflow already gates these steps on non-PR events:
- Login to Docker Hub
- Attest build provenance
- Sign image with cosign (keyless)

`Install cosign` was the only step in that subgroup running on PRs without purpose — the signing step that would consume the binary is already gated. PR #32 hit a transient 502 from GitHub releases CDN during cosign install, requiring a re-run. This change eliminates that flake surface for PR builds.

## Verification plan

- [ ] PR build shows `Install cosign` as skipped
- [ ] Post-merge main run signs `:latest` correctly
- [ ] `cosign verify` against `:latest` passes after merge