### PR TITLE
docs(readme): link to IMAGE-PUBLISHING-RUNBOOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
     - [Optional “real” checks (with mounted config)](#optional-real-checks-with-mounted-config)
   - [Security Notes](#security-notes)
   - [Run as root (override)](#run-as-root-override)
+  - [Standardization reference](#standardization-reference)
   - [About the maintainer](#about-the-maintainer)
 
 This image streamlines work with Amazon Web Services (AWS) and Kubernetes by bundling **AWS CLI v2** (`aws`) and **kubectl** on **Ubuntu 24.04**. It also includes `jq`, `curl`, `unzip`, and `envsubst` (from `gettext-base`). Perfect for CI/CD steps, automation, and reproducible local scripting.
@@ -402,6 +403,20 @@ If a specific workflow requires root inside the container (e.g. installing addit
 ```bash
 docker run --rm --user 0:0 heyvaldemar/aws-kubectl bash
 ```
+
+## Standardization reference
+
+The patterns in this image are codified as a reusable standard at [`heyvaldemar/self-host-repo-hardening-runbook` → `IMAGE-PUBLISHING-RUNBOOK.md`](https://github.com/heyvaldemar/self-host-repo-hardening-runbook/blob/main/IMAGE-PUBLISHING-RUNBOOK.md). If you maintain a Dockerfile-based repo and want to follow the same standard, the runbook covers:
+
+- Multi-stage Dockerfile with base-image digest pinning
+- Full OCI labels (`org.opencontainers.image.*`)
+- BuildKit attestations (SBOM + SLSA `provenance: mode=max`)
+- Cosign keyless signing via Sigstore (with rationale for pinning Cosign v2.6.1 over v3.x)
+- Tag retention + Docker Hub immutability policy
+- Weekly base-image rebuild via cron
+- Pinning guidance documentation for downstream consumers
+
+Six mandatory phases plus an optional non-root migration phase for repos with existing `:latest` audiences. Eight production-grounded pitfalls drawn from this repo's own PR history.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a "Standardization reference" section to the README pointing at [`self-host-repo-hardening-runbook` → `IMAGE-PUBLISHING-RUNBOOK.md`](https://github.com/heyvaldemar/self-host-repo-hardening-runbook/blob/main/IMAGE-PUBLISHING-RUNBOOK.md). That runbook (released as v1.3.0 today) codifies the patterns in this image as a reusable standard for any Dockerfile-based image-publishing repo.

## Why

Other maintainers adopting aws-kubectl-docker's supply-chain patterns (multi-stage build + digest pinning + OCI labels + cosign + SBOM + SLSA + tag immutability) previously had to read this repo's PR history to reverse-engineer the patterns. The new runbook gives them six step-by-step phases with verbatim snippets and eight production-grounded pitfalls — drawn from this repo's own iteration history — without the archaeology.

## What changed

One-section addition in `README.md`, placed between "Run as root (override)" and the maintainer footer. TOC entry added. No code, workflow, or Dockerfile change.

## Test plan

- [x] README renders cleanly on GitHub (Markdown links resolve, TOC anchor works)
- [x] No effect on CI workflow surface — Dockerfile, scripts, and YAML untouched
- [x] Existing `lint` and `build` jobs run on this PR as a smoke check