### PR TITLE
fix(ci): scope sha-* tag emission to push and pull_request events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix=sha-,format=short
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
             type=raw,value=kube-${{ steps.kube.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
           labels: |
             org.opencontainers.image.title=aws-kubectl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SHA returned by GitHub's `git/refs/tags/...` API; Scorecard's
   imposter-commit verification rejected it and refused to publish results,
   blocking README badge activation. `v2.4.3` itself is unchanged.
+- CI workflow: `sha-*` tag emission scoped to `push` and `pull_request`
+  events only. Same root cause as the prior `kube-v*` and `:latest` fixes:
+  the weekly scheduled rebuild and `workflow_dispatch` reuse the source SHA
+  but produce a fresh image manifest digest (newer base layers), and pushing
+  to `sha-<X>` is rejected by Docker Hub's tag-immutability policy with
+  HTTP 403. Surfaced by the 2026-05-04 cron run, which collided with the
+  `sha-0546ce8` tag pushed earlier the same day by the Dependabot
+  `github/codeql-action` bump (PR #36). Fix mirrors the `kube-v*` pattern:
+  `enable=${{ github.event_name == 'push' || github.event_name == 'pull_request' }}`.
+  PR builds keep emitting the tag for label completeness; `push: false` keeps
+  it out of the registry. Schedule and manual dispatch now only re-tag the
+  mutable `:latest` and `:edge` channels with fresh base layers, preserving
+  the "first push owns the immutable `sha-*` tag" semantic that downstream
+  consumers depend on.
 
 ## [2.0.0] - 2026-04-21
 


### PR DESCRIPTION
## What broke

The weekly cron run [25306176213](https://github.com/heyvaldemar/aws-kubectl-docker/actions/runs/25306176213) failed at the build-and-push step:

```
ERROR: failed to push heyvaldemar/aws-kubectl:sha-0546ce8: denied: requested
access to the resource is denied - tag sha-0546ce8 is already assigned to an
image in this repository and cannot be updated due to immutability settings.
```

The build-and-push step exited 1, which short-circuited the rest of the job (attest / cosign install / cosign sign — all skipped).

## Root cause

`docker/metadata-action` was emitting `sha-<X>` on **every** event type, including `schedule` and `workflow_dispatch`. The Monday cron rebuild reused the source SHA `0546ce8` (no commit landed since the PR #36 Dependabot merge earlier the same day), pulled a fresh `ubuntu:24.04` base layer, produced a different image manifest digest, and tried to push `sha-0546ce8` — which Docker Hub's tag-immutability policy correctly rejected.

This is the same root cause as the prior `kube-v*` and `:latest` tag fixes (PR #32, the existing `flavor: latest=false`): metadata-action's default tag rules don't account for tag immutability. Each tag rule needs an explicit `enable=` predicate matching the events where re-push is safe.

## Fix

One line in `.github/workflows/publish.yml`:

```diff
-            type=sha,prefix=sha-,format=short
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
```

## Behavior after merge

| Event | sha-* emitted? | Pushed to registry? | Rationale |
|---|---|---|---|
| Push to main / push tag | ✅ | ✅ | New source SHA → fresh tag |
| Pull request | ✅ | ❌ (`push: false`) | Tag list completeness only |
| Schedule (weekly cron) | ❌ | — | Only re-tag mutable `:latest` and `:edge` with rebuilt image |
| `workflow_dispatch` | ❌ | — | Manual rebuild without source change; if source did change, push instead |

The "first push of a source SHA owns the immutable `sha-*` tag forever" semantic is preserved — which is what downstream consumers depend on when pinning by `sha-*`.

## Test plan

- [x] CI lint job runs on this PR (catches YAML parse errors)
- [x] Build job runs with `push: false` on this PR — validates the new `enable=` clause is well-formed
- [ ] After merge: next weekly cron (Monday 06:00 UTC) should pass cleanly
- [ ] Optional: I can trigger `workflow_dispatch` after merge to validate sooner

## Follow-up

I'll open a separate PR against `self-host-repo-hardening-runbook` adding this pattern as Pitfall 9 in `IMAGE-PUBLISHING-RUNBOOK.md` so future Type A repos preempt the same trap.